### PR TITLE
Improve test code quality rs

### DIFF
--- a/test/src/edu/stanford/nlp/classify/DatasetTest.java
+++ b/test/src/edu/stanford/nlp/classify/DatasetTest.java
@@ -1,53 +1,92 @@
 package edu.stanford.nlp.classify;
 
-import java.util.Arrays;
-
-import org.junit.Assert;
-import org.junit.Test;
-
 import edu.stanford.nlp.ling.BasicDatum;
 import edu.stanford.nlp.ling.Datum;
 import edu.stanford.nlp.stats.Counter;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
 
 
 /** @author Christopher Manning */
 public class DatasetTest {
 
-  @Test
-  public void testDataset() {
-    Dataset<String, String> data = new Dataset<>();
-    data.add(new BasicDatum<String, String>(Arrays.asList(new String[]{"fever", "cough", "congestion"}), "cold"));
-    data.add(new BasicDatum<String, String>(Arrays.asList(new String[]{"fever", "cough", "nausea"}), "flu"));
-    data.add(new BasicDatum<String, String>(Arrays.asList(new String[]{"cough", "congestion"}), "cold"));
+  private Dataset<String, String> data = new Dataset<>();
 
-    // data.summaryStatistics();
+  @Before
+  public void DSsetUp() {
+    data.add(new BasicDatum<String, String>(Arrays.asList("fever", "cough", "congestion"), "cold"));
+    data.add(new BasicDatum<String, String>(Arrays.asList("fever", "cough", "nausea"), "flu"));
+    data.add(new BasicDatum<String, String>(Arrays.asList("cough", "congestion"), "cold"));
+  }
+
+  @Test
+  public void testDSnumFeatures(){
     Assert.assertEquals(4, data.numFeatures());
+
+    data.applyFeatureCountThreshold(2);
+
+    Assert.assertEquals("test numFeatures after calling FeatureThreshhold",3, data.numFeatures());
+  }
+
+  @Test
+  public void testDSnumFeatureTypes() {
     Assert.assertEquals(4, data.numFeatureTypes());
-    Assert.assertEquals(2, data.numClasses());
-    Assert.assertEquals(8, data.numFeatureTokens());
+
+    data.applyFeatureCountThreshold(2);
+
+    Assert.assertEquals("test numFeatureTypes after calling FeatureThreshhold",3, data.numFeatureTypes());
+  }
+
+  @Test
+  public void testDSsize() {
     Assert.assertEquals(3, data.size());
 
     data.applyFeatureCountThreshold(2);
 
-    Assert.assertEquals(3, data.numFeatures());
-    Assert.assertEquals(3, data.numFeatureTypes());
-    Assert.assertEquals(2, data.numClasses());
-    Assert.assertEquals(7, data.numFeatureTokens());
-    Assert.assertEquals(3, data.size());
+    Assert.assertEquals("test size after calling FeatureThreshhold",3,data.size());
+  }
 
-    //Dataset data = Dataset.readSVMLightFormat(args[0]);
-    //double[] scores = data.getInformationGains();
-    //System.out.println(ArrayMath.mean(scores));
-    //System.out.println(ArrayMath.variance(scores));
+  @Test
+  public void testDSnumFeatureTokens() {
+    Assert.assertEquals(8, data.numFeatureTokens());
+
+    data.applyFeatureCountThreshold(2);
+
+    Assert.assertEquals("test numFeatureTokens after calling FeatureThreshhold",7, data.numFeatureTokens());
+  }
+
+  @Test
+  public void testDSnumClasses() {
+    Assert.assertEquals(2, data.numClasses());
+
+    data.applyFeatureCountThreshold(2);
+
+    Assert.assertEquals("test numClasses after calling FeatureThreshhold",2, data.numClasses());
+  }
+
+  @Test
+  public void testLinearClassifierClassOfUsingDS() {
+    data.applyFeatureCountThreshold(2);
     LinearClassifierFactory<String, String> factory = new LinearClassifierFactory<>();
     LinearClassifier<String, String> classifier = factory.trainClassifier(data);
+    Datum<String, String> d = new BasicDatum<>(Arrays.asList("cough", "fever"));
 
-    Datum<String, String> d = new BasicDatum<>(Arrays.asList(new String[]{"cough", "fever"}));
     Assert.assertEquals("Classification incorrect", "flu", classifier.classOf(d));
+  }
+
+  @Test
+  public void testLinearClassifierProbabilityUsingDS(){
+    data.applyFeatureCountThreshold(2);
+    LinearClassifierFactory<String, String> factory = new LinearClassifierFactory<>();
+    LinearClassifier<String, String> classifier = factory.trainClassifier(data);
+    Datum<String, String> d = new BasicDatum<>(Arrays.asList("cough", "fever"));
+
     Counter<String> probs = classifier.probabilityOf(d);
     Assert.assertEquals("Returned probability incorrect", 0.4553, probs.getCount("cold"), 0.0001);
     Assert.assertEquals("Returned probability incorrect", 0.5447, probs.getCount("flu"), 0.0001);
     System.out.println();
   }
-
 }

--- a/test/src/edu/stanford/nlp/classify/DatasetTest.java
+++ b/test/src/edu/stanford/nlp/classify/DatasetTest.java
@@ -28,7 +28,7 @@ public class DatasetTest {
 
     data.applyFeatureCountThreshold(2);
 
-    Assert.assertEquals("test numFeatures after calling FeatureThreshhold",3, data.numFeatures());
+    Assert.assertEquals("test numFeatures after calling FeatureThreshhold", 3, data.numFeatures());
   }
 
   @Test
@@ -37,7 +37,7 @@ public class DatasetTest {
 
     data.applyFeatureCountThreshold(2);
 
-    Assert.assertEquals("test numFeatureTypes after calling FeatureThreshhold",3, data.numFeatureTypes());
+    Assert.assertEquals("test numFeatureTypes after calling FeatureThreshhold", 3, data.numFeatureTypes());
   }
 
   @Test
@@ -46,7 +46,7 @@ public class DatasetTest {
 
     data.applyFeatureCountThreshold(2);
 
-    Assert.assertEquals("test size after calling FeatureThreshhold",3,data.size());
+    Assert.assertEquals("test size after calling FeatureThreshhold", 3,data.size());
   }
 
   @Test
@@ -55,7 +55,7 @@ public class DatasetTest {
 
     data.applyFeatureCountThreshold(2);
 
-    Assert.assertEquals("test numFeatureTokens after calling FeatureThreshhold",7, data.numFeatureTokens());
+    Assert.assertEquals("test numFeatureTokens after calling FeatureThreshhold", 7, data.numFeatureTokens());
   }
 
   @Test
@@ -64,7 +64,7 @@ public class DatasetTest {
 
     data.applyFeatureCountThreshold(2);
 
-    Assert.assertEquals("test numClasses after calling FeatureThreshhold",2, data.numClasses());
+    Assert.assertEquals("test numClasses after calling FeatureThreshhold", 2, data.numClasses());
   }
 
   @Test

--- a/test/src/edu/stanford/nlp/dcoref/RulesTest.java
+++ b/test/src/edu/stanford/nlp/dcoref/RulesTest.java
@@ -1,12 +1,11 @@
 package edu.stanford.nlp.dcoref;
 
+import edu.stanford.nlp.ling.CoreAnnotations;
+import edu.stanford.nlp.ling.CoreLabel;
 import edu.stanford.nlp.ling.SentenceUtils;
 import junit.framework.TestCase;
 
 import java.util.List;
-
-import edu.stanford.nlp.ling.CoreAnnotations;
-import edu.stanford.nlp.ling.CoreLabel;
 
 /**
  * Test some of the "rules" which compose the coref system
@@ -20,12 +19,12 @@ public class RulesTest extends TestCase {
   List<CoreLabel> MIBM = SentenceUtils.toCoreLabelList("MIBM");
 
   public void testIsAcronym() {
-    assertTrue(Rules.isAcronym(IBM, IBM2));
-    assertTrue(Rules.isAcronym(IBM2, IBM));
-    assertFalse(Rules.isAcronym(IBM, IBMM));
-    assertFalse(Rules.isAcronym(IBM2, IBMM));
-    assertFalse(Rules.isAcronym(IBM, MIBM));
-    assertFalse(Rules.isAcronym(IBM2, MIBM));
+    assertTrue("Acronym IMB -> International Business Machines",Rules.isAcronym(IBM, IBM2));
+    assertTrue("Acronym International Business Machines -> IBM",Rules.isAcronym(IBM2, IBM));
+    assertFalse("Not Acronym IBM -> IBMM",Rules.isAcronym(IBM, IBMM));
+    assertFalse("Not Acronym International Business Machines -> IBMM",Rules.isAcronym(IBM2, IBMM));
+    assertFalse("Not Acronym IBM -> MIBM",Rules.isAcronym(IBM, MIBM));
+    assertFalse("Not acronym International Business Machines -> MIBM",Rules.isAcronym(IBM2, MIBM));
   }
 
   public void testMentionMatchesSpeakerAnnotation() {

--- a/test/src/edu/stanford/nlp/dcoref/RulesTest.java
+++ b/test/src/edu/stanford/nlp/dcoref/RulesTest.java
@@ -19,12 +19,12 @@ public class RulesTest extends TestCase {
   List<CoreLabel> MIBM = SentenceUtils.toCoreLabelList("MIBM");
 
   public void testIsAcronym() {
-    assertTrue("Acronym IMB -> International Business Machines",Rules.isAcronym(IBM, IBM2));
-    assertTrue("Acronym International Business Machines -> IBM",Rules.isAcronym(IBM2, IBM));
-    assertFalse("Not Acronym IBM -> IBMM",Rules.isAcronym(IBM, IBMM));
-    assertFalse("Not Acronym International Business Machines -> IBMM",Rules.isAcronym(IBM2, IBMM));
-    assertFalse("Not Acronym IBM -> MIBM",Rules.isAcronym(IBM, MIBM));
-    assertFalse("Not acronym International Business Machines -> MIBM",Rules.isAcronym(IBM2, MIBM));
+    assertTrue("Acronym IMB -> International Business Machines", Rules.isAcronym(IBM, IBM2));
+    assertTrue("Acronym International Business Machines -> IBM", Rules.isAcronym(IBM2, IBM));
+    assertFalse("Not Acronym IBM -> IBMM", Rules.isAcronym(IBM, IBMM));
+    assertFalse("Not Acronym International Business Machines -> IBMM", Rules.isAcronym(IBM2, IBMM));
+    assertFalse("Not Acronym IBM -> MIBM", Rules.isAcronym(IBM, MIBM));
+    assertFalse("Not acronym International Business Machines -> MIBM", Rules.isAcronym(IBM2, MIBM));
   }
 
   public void testMentionMatchesSpeakerAnnotation() {

--- a/test/src/edu/stanford/nlp/graph/DirectedMultiGraphTest.java
+++ b/test/src/edu/stanford/nlp/graph/DirectedMultiGraphTest.java
@@ -1,9 +1,9 @@
 package edu.stanford.nlp.graph;
 
-import java.util.*;
-
 import edu.stanford.nlp.util.CollectionUtils;
 import junit.framework.TestCase;
+
+import java.util.*;
 
 public class DirectedMultiGraphTest extends TestCase {
 
@@ -48,21 +48,34 @@ public class DirectedMultiGraphTest extends TestCase {
     assertEquals(graph.getNumEdges(), 7);
   }
 
-  public void testRemove() {
-    graph.removeVertex(2);
+  public void testRemoveEdges() {
+    assertTrue(graph.removeEdges(2, 3));
+
+    System.out.println("after deleting 2->3 edge\n" + graph.toString());
+
+    assertEquals(graph.getNumVertices(), 10);
+    assertEquals(graph.getNumEdges(), 6);
+  }
+
+  public void testRemoveNonExistingEdges() {
+    graph.removeEdges(2, 3);
+
+    assertFalse(graph.removeEdges(2, 3));
+  }
+
+  public void testRemoveVertex() {
+    assertTrue(graph.removeVertex(2));
+
     System.out.println("after deleting 2\n" + graph.toString());
+
     assertEquals(graph.getNumVertices(), 9);
     assertEquals(graph.getNumEdges(), 5);
+  }
+
+  public void testRemoveNonExistingVertex() {
     // vertex 11 doesn't exist in the graph and thus this function should return
     // false
     assertFalse(graph.removeVertex(11));
-
-    setUp();
-    assertTrue(graph.removeEdges(2, 3));
-    System.out.println("after deleting 2->3 edge\n" + graph.toString());
-    assertEquals(graph.getNumVertices(), 10);
-    assertEquals(graph.getNumEdges(), 6);
-    assertFalse(graph.removeEdges(2, 3));
   }
 
   public void testDelZeroDegreeNodes() {

--- a/test/src/edu/stanford/nlp/international/spanish/SpanishUnknownWordSignaturesTest.java
+++ b/test/src/edu/stanford/nlp/international/spanish/SpanishUnknownWordSignaturesTest.java
@@ -8,22 +8,22 @@ import junit.framework.TestCase;
 public class SpanishUnknownWordSignaturesTest extends TestCase {
 
   public void testHasConditionalSuffix() {
-    assertTrue("debería has conditional suffix",SpanishUnknownWordSignatures.hasConditionalSuffix("debería"));
-    assertTrue("deberías has conditional suffix",SpanishUnknownWordSignatures.hasConditionalSuffix("deberías"));
-    assertTrue("deberíamos has conditional suffix",SpanishUnknownWordSignatures.hasConditionalSuffix("deberíamos"));
-    assertTrue("deberíais has conditional suffix",SpanishUnknownWordSignatures.hasConditionalSuffix("deberíais"));
-    assertTrue("deberían has conditional suffix",SpanishUnknownWordSignatures.hasConditionalSuffix("deberían"));
+    assertTrue("debería has conditional suffix", SpanishUnknownWordSignatures.hasConditionalSuffix("debería"));
+    assertTrue("deberías has conditional suffix", SpanishUnknownWordSignatures.hasConditionalSuffix("deberías"));
+    assertTrue("deberíamos has conditional suffix", SpanishUnknownWordSignatures.hasConditionalSuffix("deberíamos"));
+    assertTrue("deberíais has conditional suffix", SpanishUnknownWordSignatures.hasConditionalSuffix("deberíais"));
+    assertTrue("deberían has conditional suffix", SpanishUnknownWordSignatures.hasConditionalSuffix("deberían"));
 
-    assertFalse("debía no conditional suffix",SpanishUnknownWordSignatures.hasConditionalSuffix("debía"));
-    assertFalse("debías no conditional suffix",SpanishUnknownWordSignatures.hasConditionalSuffix("debías"));
-    assertFalse("debíamos no conditional suffix",SpanishUnknownWordSignatures.hasConditionalSuffix("debíamos"));
-    assertFalse("debíais no conditional suffix",SpanishUnknownWordSignatures.hasConditionalSuffix("debíais"));
-    assertFalse("debían no conditional suffix",SpanishUnknownWordSignatures.hasConditionalSuffix("debían"));
+    assertFalse("debía no conditional suffix", SpanishUnknownWordSignatures.hasConditionalSuffix("debía"));
+    assertFalse("debías no conditional suffix", SpanishUnknownWordSignatures.hasConditionalSuffix("debías"));
+    assertFalse("debíamos no conditional suffix", SpanishUnknownWordSignatures.hasConditionalSuffix("debíamos"));
+    assertFalse("debíais no conditional suffix", SpanishUnknownWordSignatures.hasConditionalSuffix("debíais"));
+    assertFalse("debían no conditional suffix", SpanishUnknownWordSignatures.hasConditionalSuffix("debían"));
   }
 
   public void testHasImperfectErIrSuffix() {
-    assertTrue("vivía has imperfect Er Ir Suffix",SpanishUnknownWordSignatures.hasImperfectErIrSuffix("vivía"));
-    assertFalse("viviría does not have imperfect Er Ir Suffix",SpanishUnknownWordSignatures.hasImperfectErIrSuffix("viviría"));
+    assertTrue("vivía has imperfect Er Ir Suffix", SpanishUnknownWordSignatures.hasImperfectErIrSuffix("vivía"));
+    assertFalse("viviría does not have imperfect Er Ir Suffix", SpanishUnknownWordSignatures.hasImperfectErIrSuffix("viviría"));
   }
 
 }

--- a/test/src/edu/stanford/nlp/international/spanish/SpanishUnknownWordSignaturesTest.java
+++ b/test/src/edu/stanford/nlp/international/spanish/SpanishUnknownWordSignaturesTest.java
@@ -8,22 +8,22 @@ import junit.framework.TestCase;
 public class SpanishUnknownWordSignaturesTest extends TestCase {
 
   public void testHasConditionalSuffix() {
-    assertTrue(SpanishUnknownWordSignatures.hasConditionalSuffix("debería"));
-    assertTrue(SpanishUnknownWordSignatures.hasConditionalSuffix("deberías"));
-    assertTrue(SpanishUnknownWordSignatures.hasConditionalSuffix("deberíamos"));
-    assertTrue(SpanishUnknownWordSignatures.hasConditionalSuffix("deberíais"));
-    assertTrue(SpanishUnknownWordSignatures.hasConditionalSuffix("deberían"));
+    assertTrue("debería has conditional suffix",SpanishUnknownWordSignatures.hasConditionalSuffix("debería"));
+    assertTrue("deberías has conditional suffix",SpanishUnknownWordSignatures.hasConditionalSuffix("deberías"));
+    assertTrue("deberíamos has conditional suffix",SpanishUnknownWordSignatures.hasConditionalSuffix("deberíamos"));
+    assertTrue("deberíais has conditional suffix",SpanishUnknownWordSignatures.hasConditionalSuffix("deberíais"));
+    assertTrue("deberían has conditional suffix",SpanishUnknownWordSignatures.hasConditionalSuffix("deberían"));
 
-    assertFalse(SpanishUnknownWordSignatures.hasConditionalSuffix("debía"));
-    assertFalse(SpanishUnknownWordSignatures.hasConditionalSuffix("debías"));
-    assertFalse(SpanishUnknownWordSignatures.hasConditionalSuffix("debíamos"));
-    assertFalse(SpanishUnknownWordSignatures.hasConditionalSuffix("debíais"));
-    assertFalse(SpanishUnknownWordSignatures.hasConditionalSuffix("debían"));
+    assertFalse("debía no conditional suffix",SpanishUnknownWordSignatures.hasConditionalSuffix("debía"));
+    assertFalse("debías no conditional suffix",SpanishUnknownWordSignatures.hasConditionalSuffix("debías"));
+    assertFalse("debíamos no conditional suffix",SpanishUnknownWordSignatures.hasConditionalSuffix("debíamos"));
+    assertFalse("debíais no conditional suffix",SpanishUnknownWordSignatures.hasConditionalSuffix("debíais"));
+    assertFalse("debían no conditional suffix",SpanishUnknownWordSignatures.hasConditionalSuffix("debían"));
   }
 
   public void testHasImperfectErIrSuffix() {
-    assertTrue(SpanishUnknownWordSignatures.hasImperfectErIrSuffix("vivía"));
-    assertFalse(SpanishUnknownWordSignatures.hasImperfectErIrSuffix("viviría"));
+    assertTrue("vivía has imperfect Er Ir Suffix",SpanishUnknownWordSignatures.hasImperfectErIrSuffix("vivía"));
+    assertFalse("viviría does not have imperfect Er Ir Suffix",SpanishUnknownWordSignatures.hasImperfectErIrSuffix("viviría"));
   }
 
 }

--- a/test/src/edu/stanford/nlp/ling/CategoryWordTagFactoryTest.java
+++ b/test/src/edu/stanford/nlp/ling/CategoryWordTagFactoryTest.java
@@ -1,6 +1,7 @@
 package edu.stanford.nlp.ling;
 
 import junit.framework.TestCase;
+import org.junit.Test;
 
 public class CategoryWordTagFactoryTest extends TestCase {
   public void testCopy() {
@@ -12,5 +13,13 @@ public class CategoryWordTagFactoryTest extends TestCase {
     assertEquals("A", tag2.category());
     assertEquals("B", tag2.word());
     assertEquals("C", tag2.tag());
+  }
+
+  @Test
+  public void testNewLabelMethodReturnsInstanceOfCategoryWordTag(){
+      CategoryWordTag tag = new CategoryWordTag("A", "B", "C");
+      CategoryWordTagFactory lf = new CategoryWordTagFactory();
+      Label label = lf.newLabel(tag);
+      assertTrue(label instanceof CategoryWordTag);
   }
 }

--- a/test/src/edu/stanford/nlp/ling/CategoryWordTagFactoryTest.java
+++ b/test/src/edu/stanford/nlp/ling/CategoryWordTagFactoryTest.java
@@ -5,10 +5,6 @@ import junit.framework.TestCase;
 public class CategoryWordTagFactoryTest extends TestCase {
   public void testCopy() {
     CategoryWordTag tag = new CategoryWordTag("A", "B", "C");
-    assertEquals("A", tag.category());
-    assertEquals("B", tag.word());
-    assertEquals("C", tag.tag());
-
     CategoryWordTagFactory lf = new CategoryWordTagFactory();
     Label label = lf.newLabel(tag);
     assertTrue(label instanceof CategoryWordTag);

--- a/test/src/edu/stanford/nlp/ling/CategoryWordTagFactoryTest.java
+++ b/test/src/edu/stanford/nlp/ling/CategoryWordTagFactoryTest.java
@@ -1,25 +1,14 @@
 package edu.stanford.nlp.ling;
 
 import junit.framework.TestCase;
-import org.junit.Test;
 
 public class CategoryWordTagFactoryTest extends TestCase {
-  public void testCopy() {
+
+  public void testNewLabelMethodReturnsInstanceOfCategoryWordTag(){
     CategoryWordTag tag = new CategoryWordTag("A", "B", "C");
     CategoryWordTagFactory lf = new CategoryWordTagFactory();
     Label label = lf.newLabel(tag);
-    assertTrue(label instanceof CategoryWordTag);
-    CategoryWordTag tag2 = (CategoryWordTag) label;
-    assertEquals("A", tag2.category());
-    assertEquals("B", tag2.word());
-    assertEquals("C", tag2.tag());
-  }
 
-  @Test
-  public void testNewLabelMethodReturnsInstanceOfCategoryWordTag(){
-      CategoryWordTag tag = new CategoryWordTag("A", "B", "C");
-      CategoryWordTagFactory lf = new CategoryWordTagFactory();
-      Label label = lf.newLabel(tag);
-      assertTrue(label instanceof CategoryWordTag);
+    assertTrue(label instanceof CategoryWordTag);
   }
 }

--- a/test/src/edu/stanford/nlp/ling/CategoryWordTagTest.java
+++ b/test/src/edu/stanford/nlp/ling/CategoryWordTagTest.java
@@ -9,17 +9,17 @@ public class CategoryWordTagTest extends TestCase {
 
     CategoryWordTag tag2 = new CategoryWordTag(tag);
 
-    assertEquals("A", tag2.category());
-    assertEquals("B", tag2.word());
-    assertEquals("C", tag2.tag());
+    assertEquals("Testing method category","A", tag2.category());
+    assertEquals("Testing method word","B", tag2.word());
+    assertEquals("Testing method tag","C", tag2.tag());
   }
 
   @Test
   public void testCategoryWordTagConstructorWithParCategoryWordTag() {
     CategoryWordTag tag = new CategoryWordTag("A", "B", "C");
 
-    assertEquals("A", tag.category());
-    assertEquals("B", tag.word());
-    assertEquals("C", tag.tag());
+    assertEquals("Testing method category","A", tag.category());
+    assertEquals("Testing method category","B", tag.word());
+    assertEquals("Testing method category","C", tag.tag());
   }
 }

--- a/test/src/edu/stanford/nlp/ling/CategoryWordTagTest.java
+++ b/test/src/edu/stanford/nlp/ling/CategoryWordTagTest.java
@@ -9,17 +9,17 @@ public class CategoryWordTagTest extends TestCase {
 
     CategoryWordTag tag2 = new CategoryWordTag(tag);
 
-    assertEquals("Testing method category","A", tag2.category());
-    assertEquals("Testing method word","B", tag2.word());
-    assertEquals("Testing method tag","C", tag2.tag());
+    assertEquals("Testing method category", "A", tag2.category());
+    assertEquals("Testing method word", "B", tag2.word());
+    assertEquals("Testing method tag", "C", tag2.tag());
   }
 
   @Test
   public void testCategoryWordTagConstructorWithParCategoryWordTag() {
     CategoryWordTag tag = new CategoryWordTag("A", "B", "C");
 
-    assertEquals("Testing method category","A", tag.category());
-    assertEquals("Testing method category","B", tag.word());
-    assertEquals("Testing method category","C", tag.tag());
+    assertEquals("Testing method category", "A", tag.category());
+    assertEquals("Testing method word", "B", tag.word());
+    assertEquals("Testing method tag", "C", tag.tag());
   }
 }

--- a/test/src/edu/stanford/nlp/ling/CategoryWordTagTest.java
+++ b/test/src/edu/stanford/nlp/ling/CategoryWordTagTest.java
@@ -1,17 +1,25 @@
 package edu.stanford.nlp.ling;
 
 import junit.framework.TestCase;
+import org.junit.Test;
 
 public class CategoryWordTagTest extends TestCase {
-  public void testCopy() {
+  public void testCategoryWordTagConstructorWithExistingLabel() {
     CategoryWordTag tag = new CategoryWordTag("A", "B", "C");
-    assertEquals("A", tag.category());
-    assertEquals("B", tag.word());
-    assertEquals("C", tag.tag());
 
     CategoryWordTag tag2 = new CategoryWordTag(tag);
+
     assertEquals("A", tag2.category());
     assertEquals("B", tag2.word());
     assertEquals("C", tag2.tag());
+  }
+
+  @Test
+  public void testCategoryWordTagConstructorWithParCategoryWordTag() {
+    CategoryWordTag tag = new CategoryWordTag("A", "B", "C");
+
+    assertEquals("A", tag.category());
+    assertEquals("B", tag.word());
+    assertEquals("C", tag.tag());
   }
 }

--- a/test/src/edu/stanford/nlp/math/SloppyMathTest.java
+++ b/test/src/edu/stanford/nlp/math/SloppyMathTest.java
@@ -10,12 +10,12 @@ public class SloppyMathTest extends TestCase {
   }
 
   public void testRoundWithBoundaries() {
-    assertEquals(0.0, SloppyMath.round(0.499));
-    assertEquals(1.0, SloppyMath.round(0.5));
-    assertEquals(0.0, SloppyMath.round(-0.5));
-    assertEquals(-1.0, SloppyMath.round(-0.51));
-    assertEquals(10.0, SloppyMath.round(10));
-    assertEquals(10.0, SloppyMath.round(10.32));
+    assertEquals("Boundary off point positive",0.0, SloppyMath.round(0.499));
+    assertEquals("Boundary on point",1.0, SloppyMath.round(0.5));
+    assertEquals("Boundary on point negative",0.0, SloppyMath.round(-0.5));
+    assertEquals("Boundary off point negative",-1.0, SloppyMath.round(-0.51));
+    assertEquals("Round 10 to 10",10.0, SloppyMath.round(10));
+    assertEquals("Round 10.32 to 10",10.0, SloppyMath.round(10.32));
   }
 
   public void testRound2() {

--- a/test/src/edu/stanford/nlp/math/SloppyMathTest.java
+++ b/test/src/edu/stanford/nlp/math/SloppyMathTest.java
@@ -10,12 +10,12 @@ public class SloppyMathTest extends TestCase {
   }
 
   public void testRoundWithBoundaries() {
-    assertEquals("Boundary off point positive",0.0, SloppyMath.round(0.499));
-    assertEquals("Boundary on point",1.0, SloppyMath.round(0.5));
-    assertEquals("Boundary on point negative",0.0, SloppyMath.round(-0.5));
-    assertEquals("Boundary off point negative",-1.0, SloppyMath.round(-0.51));
-    assertEquals("Round 10 to 10",10.0, SloppyMath.round(10));
-    assertEquals("Round 10.32 to 10",10.0, SloppyMath.round(10.32));
+    assertEquals("Boundary off point positive", 0.0, SloppyMath.round(0.499));
+    assertEquals("Boundary on point", 1.0, SloppyMath.round(0.5));
+    assertEquals("Boundary on point negative", 0.0, SloppyMath.round(-0.5));
+    assertEquals("Boundary off point negative", -1.0, SloppyMath.round(-0.51));
+    assertEquals("Round 10 to 10", 10.0, SloppyMath.round(10));
+    assertEquals("Round 10.32 to 10", 10.0, SloppyMath.round(10.32));
   }
 
   public void testRound2() {


### PR DESCRIPTION
In the **datasetTest** class removed code smell of **assertion Roulette** and **eager test** by dividing/extracting the testDataset method into testDSnumFeatures,testDSnumFeatureTypes, testDSsize, testDSnumFeatureTokens, testDSnumClasses, testLinearClassifierProbabilityUsingDS, testLinearClassifierClassOfUsing DS.

In the **CategoryWordTagFactoryTest** first removed code smells of **eager Test** by extracting the method, and then removed code smell of **indirect testing** because it was testing another class method CategoryWordTagTest methods, which is tested in its class.

In the **CategoryWordTagTest** removed code smell of **eager Test** by dividing/extracting testCopy method to two methods test testCategoryWordTagConstructorWithExistingLabel and testCategoryWordTagConstructorWithParCategoryWordTag, and also removed **assertion roulette** by including test messages.

In the **DirectedMultiGraphTest** removed code smell of **eager test** by spliting method testRemove into 4 different methods, testRemoveEdges, testRemoveNonExistingEdges, testRemoveVertex, testRemoveNonExistingVertex.

In the **RulesTest** class, testIsAcronym method, removed the **assertion Roulette** test smell by including test messages.

In the **SpanishUnknownWordSignature** class, removed **assertion roulette** test smell by including test messages.

In the **SloppyMathTest** class method, testRoundWithBoundaries removed the **assertion roulette** test smell by including test messages.

